### PR TITLE
Add *.import to .gitignore to exclude Godot asset import files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ $RECYCLE.BIN/
 *.msm
 *.msp
 *.lnk
+*.import


### PR DESCRIPTION
This pull request adds the *.import pattern to the .gitignore file. By ignoring these files, we prevent Godot's asset import files from being tracked in version control, keeping the repository clean and focused on source code.