### PR TITLE
Repeat patterns in arrangement by stretching

### DIFF
--- a/gui/views/pattern_map/PatternMap.gd
+++ b/gui/views/pattern_map/PatternMap.gd
@@ -1008,6 +1008,9 @@ class DraggedPatternPreview extends Control:
 	var reflect_transient_state: bool = false
 	var starting_pos: Vector2 = Vector2(-1, -1)
 	
+	func _process(delta: float) -> void:
+		queue_redraw()
+	
 	func _input(event: InputEvent) -> void:
 		if not reflect_transient_state:
 			return

--- a/gui/views/pattern_map/PatternMap.gd
+++ b/gui/views/pattern_map/PatternMap.gd
@@ -742,22 +742,22 @@ func _set_pattern_over_range(starting_pos: Vector2, ending_pos: Vector2, pattern
 	# Jump to the next row; no point adding the pattern where it already is
 	_add_head_position.x += _pattern_width
 	
+	var arrangement_state := Controller.state_manager.create_state_change(StateManager.StateChangeType.ARRANGEMENT)
+	
 	while _add_head_position.x < ending_pos.x:
-		_set_pattern_at_position(_add_head_position, pattern_idx)
+		_set_pattern_at_position_uncommitted(arrangement_state, _add_head_position, pattern_idx)
 		_add_head_position.x += _pattern_width
 	
-func _set_pattern_at_position(at_position: Vector2, pattern_idx: int) -> void:
-	if not current_arrangement || not Controller.current_song:
-		return
+	Controller.state_manager.commit_state_change(arrangement_state)
 	
+func _set_pattern_at_position_uncommitted(arrangement_state, at_position: Vector2, pattern_idx: int) -> void:
 	var cell := _get_cell_at_position(at_position)
 	var bar_index := cell.x + _scroll_offset
 	if bar_index < 0 || bar_index >= Arrangement.BAR_NUMBER:
 		return
 	if cell.y < 0 || cell.y >= Arrangement.CHANNEL_NUMBER:
 		return
-	
-	var arrangement_state := Controller.state_manager.create_state_change(StateManager.StateChangeType.ARRANGEMENT)
+		
 	arrangement_state.add_setget_property(current_arrangement, "pattern", pattern_idx,
 		# Getter.
 		func() -> int:
@@ -770,6 +770,14 @@ func _set_pattern_at_position(at_position: Vector2, pattern_idx: int) -> void:
 			else:
 				current_arrangement.set_pattern(bar_index, cell.y, value)
 	)
+	
+func _set_pattern_at_position(at_position: Vector2, pattern_idx: int) -> void:
+	if not current_arrangement || not Controller.current_song:
+		return
+	
+	var arrangement_state := Controller.state_manager.create_state_change(StateManager.StateChangeType.ARRANGEMENT)
+	
+	_set_pattern_at_position_uncommitted(arrangement_state, at_position, pattern_idx)
 	
 	Controller.state_manager.commit_state_change(arrangement_state)
 

--- a/gui/views/pattern_map/PatternMapItems.gd
+++ b/gui/views/pattern_map/PatternMapItems.gd
@@ -68,6 +68,22 @@ func draw_item(on_control: Control, pattern: PatternMap.ActivePattern, item_orig
 	var notes_area_position := item_origin + pattern.notes_area.position
 	var label_underline_position := item_origin + pattern.label_underline_area.position
 	
+	# Same hack as later on. Hey, it works!
+	if on_control.get("stretched"):
+		var starting_pos = on_control.get("starting_pos")
+		var ending_pos = on_control.position
+		
+		var _add_head_position = starting_pos
+		# Jump to the next row; no point adding the pattern where it already is
+		_add_head_position.x += pattern.item_size.x
+		
+		while _add_head_position.x < ending_pos.x:
+			# Rescale the coords so they can be drawn relative to the dragged control
+			# For some reason the origin is in the bottom left, hence adding item_size.y
+			var _relative_coords = _add_head_position - on_control.position + Vector2(0, pattern.item_size.y - 4)
+			on_control.draw_rect(Rect2(_relative_coords, pattern.item_size), pattern.gutter_color)
+			_add_head_position.x += pattern.item_size.x
+	
 	on_control.draw_rect(Rect2(item_position, pattern.item_size), pattern.gutter_color)
 	on_control.draw_rect(Rect2(notes_area_position, pattern.notes_area.size), pattern.main_color)
 	on_control.draw_rect(Rect2(label_underline_position, pattern.label_underline_area.size), pattern.main_color)

--- a/gui/views/pattern_map/PatternMapItems.gd
+++ b/gui/views/pattern_map/PatternMapItems.gd
@@ -7,6 +7,8 @@
 @tool
 extends Control
 
+@onready var _timeline: Control = %PatternMapTimeline
+
 var active_patterns: Array[PatternMap.ActivePattern] = []
 
 # Theme cache.
@@ -58,7 +60,6 @@ func _draw() -> void:
 				selected_rects.push_back(Rect2(item_position, pattern.item_size))
 	
 	# Draw selected indicator on top of everything.
-	
 	for item_rect in selected_rects:
 		_draw_selected_outline(self, item_rect)
 
@@ -72,6 +73,8 @@ func draw_item(on_control: Control, pattern: PatternMap.ActivePattern, item_orig
 	if on_control.get("stretched"):
 		var starting_pos = on_control.get("starting_pos")
 		var ending_pos = on_control.position
+		# Clamp to end of screen. Need to subtract one width because the last column goes off screen
+		ending_pos.x = min(ending_pos.x, _timeline.size.x - pattern.item_size.x)
 		
 		var _add_head_position = starting_pos
 		# Jump to the next row; no point adding the pattern where it already is

--- a/gui/views/pattern_map/PatternMapItems.gd
+++ b/gui/views/pattern_map/PatternMapItems.gd
@@ -45,7 +45,6 @@ func _update_theme() -> void:
 
 func _draw() -> void:
 	var selected_rects: Array[Rect2] = []
-	
 	for pattern in active_patterns:
 		if pattern.grid_positions.size() <= 0:
 			continue
@@ -62,7 +61,7 @@ func _draw() -> void:
 	# Draw selected indicator on top of everything.
 	for item_rect in selected_rects:
 		_draw_selected_outline(self, item_rect)
-
+		
 
 func draw_item(on_control: Control, pattern: PatternMap.ActivePattern, item_origin: Vector2, draw_selected: bool = false) -> void:
 	var item_position := item_origin + pattern.item_position


### PR DESCRIPTION
Working on issue #88, holding "a" while dragging will put the pattern in all rows between where it started and where it was dropped. Has a preview graphic (a little rough) and works correctly with the undo tree.